### PR TITLE
Fixed the href anchor tags in the nav bar

### DIFF
--- a/Project Food Menu/index.html
+++ b/Project Food Menu/index.html
@@ -29,8 +29,8 @@
               <span class="line line3"></span>
           </div>
           <ul class="menu-items">
-              <li><a href="#home">Home</a></li>
-              <li><a href="#about">About</a></li>
+              <li><a href="#showcase">Home</a></li>
+              <li><a href="#about block">About</a></li>
               <li><a href="#food">Category</a></li>
               <li><a href="#food-menu">Menu</a></li>
               <li><a href="#testimonials">Testimonial</a></li>
@@ -62,7 +62,7 @@
         </div>
       </div>
     </section>
-    <section id="food " class="block">
+    <section id="food" class="block">
       <h2 class="heading2">Types of food</h2>
       <div class="food-container container">
         <div class="food-type fruite">


### PR DESCRIPTION
Changes made  

1) Home Link Navigation: Clicking the "Home" link currently directs users to  the intended "EAT RIGHT FOOD" section.

2) About Link Navigation: The "About" link navigate to the "About" section when clicked.

3) Category Link Navigation: The "Category" link redirect users to the "Types of food" section.


https://github.com/user-attachments/assets/5bad8d60-579e-4d28-bd1a-c8425b2e71f2

